### PR TITLE
System Brightness

### DIFF
--- a/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
+++ b/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
@@ -18,21 +18,28 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 
 public class ScreenBrightnessModule extends ReactContextBaseJavaModule {
-    public static final int REQUEST_WRITE_SETTINGS_PERMISSION = 2525;
+    public static final String MODULE_NAME = "ScreenBrightness";
+
     private static final String PERMISSION_EVENT_NAME = "screenBrightnessPermission";
     private static final int BRIGHTNESS_MAX = 255;
     private static final int BRIGHTNESS_MIN = 0;
 
+    private final int mWriteSettingsRequestCode;
+
     private Activity mActivity;
 
-    public ScreenBrightnessModule(ReactApplicationContext reactApplicationContext, Activity activity) {
+    public ScreenBrightnessModule(
+            ReactApplicationContext reactApplicationContext,
+            Activity activity,
+            final int writeSettingsRequestCode) {
         super(reactApplicationContext);
         mActivity = activity;
+        mWriteSettingsRequestCode = writeSettingsRequestCode;
     }
 
     @Override
     public String getName() {
-        return "ScreenBrightness";
+        return MODULE_NAME;
     }
 
     /**
@@ -72,7 +79,7 @@ public class ScreenBrightnessModule extends ReactContextBaseJavaModule {
                     Settings.ACTION_MANAGE_WRITE_SETTINGS,
                     Uri.parse("package:" + context.getPackageName())
             );
-            mActivity.startActivityForResult(intent, REQUEST_WRITE_SETTINGS_PERMISSION);
+            mActivity.startActivityForResult(intent, mWriteSettingsRequestCode);
         }
     }
 

--- a/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
+++ b/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
@@ -63,7 +63,7 @@ public class ScreenBrightnessModule extends ReactContextBaseJavaModule {
      *
      * @return True if WRITE_SETTINGS are granted.
      */
-    public boolean hasSettingsPermission() {
+    private boolean hasSettingsPermission() {
         return Build.VERSION.SDK_INT < Build.VERSION_CODES.M ||
                 (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
                 Settings.System.canWrite(getReactApplicationContext()));

--- a/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
+++ b/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
@@ -20,7 +20,8 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 public class ScreenBrightnessModule extends ReactContextBaseJavaModule {
     public static final int REQUEST_WRITE_SETTINGS_PERMISSION = 2525;
     private static final String PERMISSION_EVENT_NAME = "screenBrightnessPermission";
-    private static final int BRIGHTNESS_RANGE = 255;
+    private static final int BRIGHTNESS_MAX = 255;
+    private static final int BRIGHTNESS_MIN = 0;
 
     private Activity mActivity;
 
@@ -101,11 +102,8 @@ public class ScreenBrightnessModule extends ReactContextBaseJavaModule {
      */
     private boolean setSystemBrightness(int brightness) {
         if (hasSettingsPermission()) {
-            if (brightness < 0) {
-                brightness = 0;
-            } else if (brightness > BRIGHTNESS_RANGE) {
-                brightness = BRIGHTNESS_RANGE;
-            }
+            // ensure brightness is bound between range 0-255
+            brightness = Math.max(BRIGHTNESS_MIN, Math.min(brightness, BRIGHTNESS_MAX));
             Settings.System.putInt(
                     getReactApplicationContext().getContentResolver(),
                     Settings.System.SCREEN_BRIGHTNESS,
@@ -145,7 +143,7 @@ public class ScreenBrightnessModule extends ReactContextBaseJavaModule {
      */
     @ReactMethod
     public void setBrightness(float brightness, final Promise promise) {
-        if (setSystemBrightness((int) brightness * BRIGHTNESS_RANGE)) {
+        if (setSystemBrightness((int) brightness * BRIGHTNESS_MAX)) {
             promise.resolve(brightness);
         } else {
             promise.reject(null);

--- a/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
+++ b/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
@@ -3,24 +3,19 @@ package com.robinpowered.react.ScreenBrightness;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.IntentFilter;
-import android.content.BroadcastReceiver;
-import android.os.BatteryManager;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.Settings;
 import android.view.WindowManager;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
-import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.Promise;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
-import com.facebook.react.bridge.LifecycleEventListener;
-
-import javax.annotation.Nullable;
 
 public class ScreenBrightnessModule extends ReactContextBaseJavaModule {
+    private static final int BRIGHTNESS_RANGE = 255;
+
     private Activity mActivity;
 
     public ScreenBrightnessModule(ReactApplicationContext reactApplicationContext, Activity activity) {
@@ -33,14 +28,86 @@ public class ScreenBrightnessModule extends ReactContextBaseJavaModule {
         return "ScreenBrightness";
     }
 
+    private boolean hasPermission() {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.M ||
+                (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                Settings.System.canWrite(getReactApplicationContext()));
+    }
+
+    private void requestPermission() {
+        Context context = getReactApplicationContext();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.System.canWrite(context)) {
+            Intent intent = new Intent(
+                    Settings.ACTION_MANAGE_WRITE_SETTINGS,
+                    Uri.parse("package:" + context.getPackageName())
+            );
+            mActivity.startActivity(intent);
+        }
+    }
+
+    private int getSystemBrightness() {
+        Integer brightness;
+        try {
+            brightness = Settings.System.getInt(
+                    getReactApplicationContext().getContentResolver(),
+                    Settings.System.SCREEN_BRIGHTNESS
+            );
+        } catch (Settings.SettingNotFoundException e) {
+            brightness = null;
+        }
+        return brightness;
+    }
+
+    private boolean setSystemBrightness(int brightness) {
+        if (hasPermission()) {
+            Settings.System.putInt(
+                    getReactApplicationContext().getContentResolver(),
+                    Settings.System.SCREEN_BRIGHTNESS,
+                    brightness
+            );
+            return true;
+        }
+        return false;
+    }
+
     @ReactMethod
-    public void getBrightness(Promise promise) {
+    public void hasPermission(final Promise promise) {
+        promise.resolve(hasPermission());
+    }
+
+    @ReactMethod
+    public void requestPermission(final Promise promise) {
+        requestPermission();
+        promise.resolve(null);
+    }
+
+    @ReactMethod
+    public void setBrightness(float brightness, final Promise promise) {
+        if (brightness > 1) {
+            brightness = 1f;
+        } else if (brightness < 0) {
+            brightness = 0f;
+        }
+        if (setSystemBrightness((int) brightness * BRIGHTNESS_RANGE)) {
+            promise.resolve(brightness);
+        } else {
+            promise.reject(null);
+        }
+    }
+
+    @ReactMethod
+    public void getBrightness(final Promise promise) {
+        promise.resolve(getSystemBrightness());
+    }
+
+    @ReactMethod
+    public void getAppBrightness(Promise promise) {
         float brightness = mActivity.getWindow().getAttributes().screenBrightness;
         promise.resolve(brightness);
     }
 
     @ReactMethod
-    public void setBrightness(final float brightness, final Promise promise) {
+    public void setAppBrightness(final float brightness, final Promise promise) {
         mActivity.runOnUiThread(new Runnable() {
             @Override
             public void run() {

--- a/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
+++ b/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
@@ -150,7 +150,7 @@ public class ScreenBrightnessModule extends ReactContextBaseJavaModule {
      */
     @ReactMethod
     public void setBrightness(float brightness, final Promise promise) {
-        if (setSystemBrightness((int) brightness * BRIGHTNESS_MAX)) {
+        if (setSystemBrightness((int) (brightness * BRIGHTNESS_MAX))) {
             promise.resolve(brightness);
         } else {
             promise.reject(null);

--- a/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessPackage.java
+++ b/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessPackage.java
@@ -25,7 +25,11 @@ public class ScreenBrightnessPackage implements ReactPackage {
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
     List<NativeModule> modules = new ArrayList<NativeModule>();
-    modules.add(new ScreenBrightnessModule(reactApplicationContext, mActivity, mWriteSettingsRequestCode));
+    modules.add(new ScreenBrightnessModule(
+            reactApplicationContext,
+            mActivity,
+            mWriteSettingsRequestCode
+    ));
     return modules;
   }
 

--- a/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessPackage.java
+++ b/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessPackage.java
@@ -15,15 +15,17 @@ import java.util.List;
 
 public class ScreenBrightnessPackage implements ReactPackage {
   private Activity mActivity = null;
+  private final int mWriteSettingsRequestCode;
 
-  public ScreenBrightnessPackage(Activity activity) {
+  public ScreenBrightnessPackage(Activity activity, final int writeSettingsRequestCode) {
     mActivity = activity;
+    mWriteSettingsRequestCode = writeSettingsRequestCode;
   }
 
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
     List<NativeModule> modules = new ArrayList<NativeModule>();
-    modules.add(new ScreenBrightnessModule(reactApplicationContext, mActivity));
+    modules.add(new ScreenBrightnessModule(reactApplicationContext, mActivity, mWriteSettingsRequestCode));
     return modules;
   }
 


### PR DESCRIPTION
This introduces changes to the `ScreenBrightness` module to allow modifying *system* brightness, and not simply app brightness.

I've updated the `getBrightness` and `setBrightness` calls to use the new system approach to allow the universal code push apps to keep using the same API for modifying brightness.