### PR TITLE
Ensure RN 0.30 compatibility

### DIFF
--- a/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessPackage.java
+++ b/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessPackage.java
@@ -39,4 +39,6 @@ public class ScreenBrightnessPackage implements ReactPackage {
   public List<ViewManager> createViewManagers(ReactApplicationContext reactApplicationContext) {
     return Arrays.<ViewManager>asList();
   }
+
+  public void onNewIntent(Intent intent) {}
 }


### PR DESCRIPTION
does fail with 'is not abstract and does not override abstract method onNewIntent(Intent)' otherwise
