### PR TITLE
Ensure RN-0.40 compatibility

### DIFF
--- a/ios/ScreenBrightness/ScreenBrightness.h
+++ b/ios/ScreenBrightness/ScreenBrightness.h
@@ -8,9 +8,9 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import "RCTBridgeModule.h"
-#import "RCTBridge.h"
-#import "RCTEventDispatcher.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTBridge.h>
+#import <React/RCTEventDispatcher.h>
 
 @interface ScreenBrightness : NSObject<RCTBridgeModule>
 

--- a/ios/ScreenBrightness/ScreenBrightness.m
+++ b/ios/ScreenBrightness/ScreenBrightness.m
@@ -7,9 +7,6 @@
 //
 
 #import "ScreenBrightness.h"
-#import "RCTBridgeModule.h"
-#import "RCTBridge.h"
-#import "RCTEventDispatcher.h"
 
 @implementation ScreenBrightness
 


### PR DESCRIPTION
Fixes React/Base/RCTBridge.h:65:1: Duplicate interface definition for class 'RCTBridge'