### PR TITLE
Bugfix - Return correct permission value for screen brightness

### DIFF
--- a/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
+++ b/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
@@ -90,9 +90,10 @@ public class ScreenBrightnessModule extends ReactContextBaseJavaModule
      * @return True if WRITE_SETTINGS are granted.
      */
     private boolean hasSettingsPermission() {
-        int responseCode = ContextCompat.checkSelfPermission(getReactApplicationContext(),
-                Manifest.permission.WRITE_SETTINGS);
-        return responseCode == PackageManager.PERMISSION_GRANTED;
+        boolean hasPermission = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+        Settings.System.canWrite(getReactApplicationContext());
+
+        return hasPermission;
     }
 
     /**


### PR DESCRIPTION
Fixed to return correct permission value for screen brightness. Turns out `ContextCompat.checkSelfPermission()` was not returning the correct response code, ~~not too sure why and it's worth checking out in the future, but due to time constraints~~, will use `Settings.System.canWrite()` to check if permissions are granted for now.

EDIT: Turns out `WRITE_SETTINGS` is a special case and the permission can only be queried using the new method. For SDK 22 and below, you get it automatically but that's not the case for newer versions. For info here: [https://stackoverflow.com/questions/32083410/cant-get-write-settings-permission](https://stackoverflow.com/questions/32083410/cant-get-write-settings-permission)