### PR TITLE
Support earlier iOS ReactNative versions & < Android 6

### DIFF
--- a/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
+++ b/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
@@ -90,8 +90,12 @@ public class ScreenBrightnessModule extends ReactContextBaseJavaModule
      * @return True if WRITE_SETTINGS are granted.
      */
     private boolean hasSettingsPermission() {
-        boolean hasPermission = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-        Settings.System.canWrite(getReactApplicationContext());
+        boolean hasPermission = true;
+
+        // Check for permisions if > Android 6
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+          hasPermission = Settings.System.canWrite(getReactApplicationContext());
+        }
 
         return hasPermission;
     }

--- a/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
+++ b/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessModule.java
@@ -61,11 +61,14 @@ public class ScreenBrightnessModule extends ReactContextBaseJavaModule
         return MODULE_NAME;
     }
 
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent intent) {
+    public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent intent) {
         if (requestCode == writeSettingsRequestCode) {
             onPermissionResult();
         }
+    }
+
+    public void onNewIntent(Intent intent) {
+
     }
 
     /**

--- a/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessPackage.java
+++ b/android/src/main/java/com/robinpowered/react/ScreenBrightness/ScreenBrightnessPackage.java
@@ -30,7 +30,6 @@ public class ScreenBrightnessPackage implements ReactPackage {
     return modules;
   }
 
-  @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/ios/ScreenBrightness.xcodeproj/project.pbxproj
+++ b/ios/ScreenBrightness.xcodeproj/project.pbxproj
@@ -212,7 +212,13 @@
 		5D72D2F21C16249000E22EC1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				HEADER_SEARCH_PATHS = "";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/node_modules/react-native/React",
+					"$(SRCROOT)/../../React/**",
+				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -222,7 +228,13 @@
 		5D72D2F31C16249000E22EC1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				HEADER_SEARCH_PATHS = "";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/node_modules/react-native/React/**",
+				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/ios/ScreenBrightness/ScreenBrightness.h
+++ b/ios/ScreenBrightness/ScreenBrightness.h
@@ -8,9 +8,15 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#if __has_include(<React/RCTBridgeModule.H>)
 #import <React/RCTBridgeModule.h>
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
+#else
+#import "RCTBridgeModule.h"
+#import "RCTBridge.h"
+#import "RCTEventDispatcher.h"
+#endif
 
 @interface ScreenBrightness : NSObject<RCTBridgeModule>
 

--- a/ios/ScreenBrightness/ScreenBrightness.m
+++ b/ios/ScreenBrightness/ScreenBrightness.m
@@ -7,6 +7,12 @@
 //
 
 #import "ScreenBrightness.h"
+#if __has_include(<React/RCTBridgeModule.H>)
+#else
+#import "RCTBridgeModule.h"
+#import "RCTBridge.h"
+#import "RCTEventDispatcher.h"
+#endif
 
 @implementation ScreenBrightness
 
@@ -14,7 +20,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(getBrightness:(RCTPromiseResolveBlock)resolve
                   getScreenBrightnessRejector:(RCTPromiseRejectBlock)reject) {
-    
+
     float brightness = [[UIScreen mainScreen] brightness];
     resolve(@(brightness));
 }


### PR DESCRIPTION
This adds a backward compatible header import for earlier React Native versions that don't support the new framework imports.

EDIT: Also adding support for < API 23, i.e. Android 6 and below