### PR TITLE
add default export, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,26 @@
 
 Access and update the system brightness on a device.
 
-_Installation guide in progress_
+## Install
+
+Install with [yarn](https://yarnpkg.com) or [npm](https://www.npmjs.com).
+
+```shell
+yarn add react-native-screen-brightness
+```
+
+```shell
+npm i --save react-native-screen-brightness
+```
 
 ## Example
+
 ```js
-import {NativeModules} from 'react-native';
-var {SystemBrightness} = NativeModules;
+import ScreenBrightness from 'react-native-screen-brightness';
 
-SystemBrightness.setBrightness(0.5) // between 0 and 1
+ScreenBrightness.setBrightness(0.5); // between 0 and 1
 
-SystemBrightness.getBrightness().then(brightness => {
+ScreenBrightness.getBrightness().then(brightness => {
   console.log('brightness', brightness);
 });
 ```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+import { NativeModules } from 'react-native';
+
+export default NativeModules.ScreenBrightness;


### PR DESCRIPTION
The example in the readme was incorrect, and in React Native-land it's common to have an `index.js` exporting the module.