### PR TITLE
androidx version as variable. v1.3.2 as default instead of generic 1.+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,8 @@ repositories {
 }
 
 dependencies {
+    def androidXCore = safeExtGet('androidXCore', "1.3.2")
+
     implementation 'com.facebook.react:react-native:+'
-    implementation 'androidx.core:core:1.+'
+    implementation "androidx.core:core:$androidXCore"
 }


### PR DESCRIPTION
To resolve some retrocompatibility issue with the new androidx version and avoid the following compiling error

```* What went wrong:
Execution failed for task ':app:processDebugResources'.
> Android resource linking failed
  .../res/values/values.xml: AAPT: error: resource android:attr/lStar not found.
      
  error: failed linking references.
```
Fix #42 